### PR TITLE
Fix: Message icon showing in absense of comments [TNL-9570]

### DIFF
--- a/src/discussions/posts/post/PostFooter.jsx
+++ b/src/discussions/posts/post/PostFooter.jsx
@@ -53,7 +53,7 @@ function PostFooter({
             />
           )}
       </OverlayTrigger>
-      {preview
+      {preview && post.commentCount > 1 //Backend returns commentCount 1 if their is no comment of post
         && (
           <>
             <Icon src={QuestionAnswer} className="mx-2 my-0" />


### PR DESCRIPTION
Fix for the problem reported in TNL-9570. Added a condition to display message icon only when comment exists. Comment for it has also been added